### PR TITLE
Fix for missing info fields

### DIFF
--- a/lib/omniauth/strategies/500px.rb
+++ b/lib/omniauth/strategies/500px.rb
@@ -22,15 +22,15 @@ module OmniAuth
       info do 
         {
           :nickname => user_info['username'],
-          :email => raw_info['email'],
+          :email => user_info['email'],
           :name => user_info['fullname'],
-          :first_name => raw_info['firstname'],
-          :last_name => raw_info['lastname'],
+          :first_name => user_info['firstname'],
+          :last_name => user_info['lastname'],
           :description => user_info['about'],
-          :image => raw_info['userpic_url'],
+          :image => user_info['userpic_url'],
           :urls => {
-            '500px' => raw_info['domain'],
-            'Website' => raw_info['contacts']['website']
+            '500px' => user_info['domain'],
+            'Website' => user_info['contacts']['website']
           }
         }
       end


### PR DESCRIPTION
I was having problems getting some of the info data as the fields were not available directly from `raw_info` and therefore were not being loaded correctly.
Updated the info section of `500px.rb` to get the fields from `user_info` and all is working now.
