### PR TITLE
Add runtime dependency: multi_json

### DIFF
--- a/omniauth-500px.gemspec
+++ b/omniauth-500px.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency 'omniauth-oauth', '~> 1.0'
+  s.add_runtime_dependency 'multi_json'
   s.add_development_dependency 'rspec', '~> 2.7'
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'simplecov'


### PR DESCRIPTION
I was trying to integrate this gem into my rails project after upgrading my version of Ruby (to 2.4) so I did not have many gems installed.  I found that when trying to start my rails server, the **omniauth-500px* gem was throwing an error where it had a [`require 'multi-json'` ](https://github.com/arthurnn/omniauth-500px/blob/master/lib/omniauth/strategies/500px.rb#L2).

I've added `multi_json` as a runtime dependency on my fork and it fixes the issue.  Hopefully this can help if anyone else encounters this issue as well.